### PR TITLE
Fixed reactive default-value setting

### DIFF
--- a/autoform-select2.js
+++ b/autoform-select2.js
@@ -158,6 +158,13 @@ Template.afSelect2.rendered = function () {
       }
     });
 
+    // set selected value
+    if( values.length == 1 ){
+      if( template.$('select option:selected').val() ){
+        $s.select2('val', template.$('select option:selected').val() );
+      }
+    }
+
     var currentValues = $s.val();
     if ((!currentValues && values.length > 0) ||
         (currentValues && currentValues.toString() !== values.toString())) {


### PR DESCRIPTION
When the options come from a reactive data source, select was not properly displaying the selected value, even though the underlaying select element had that option selected.

Calling the value setter again if a value is present appears to fix the issue.
